### PR TITLE
Use fixed proxy version

### DIFF
--- a/dork_compose/proxy/docker-compose.yml
+++ b/dork_compose/proxy/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   front:
-    image: jwilder/nginx-proxy
+    image: jwilder/nginx-proxy:0.3.6
     labels:
     - org.iamdork.proxy
     volumes:


### PR DESCRIPTION
We should always set a fixed version for images via the tags, otherwise people automatically download the latest image, which may have unexpected problems. 
