### PR TITLE
[Proxy] Don't remove every exposed port.

### DIFF
--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -82,7 +82,7 @@ class Plugin(dork_compose.plugin.Plugin):
                             if external == '443':
                                 service['environment']['VIRTUAL_PROTO'] = 'https'
                             service['environment']['VIRTUAL_PORT'] = int(internal)
-                            service['ports'] = []
+                            del service['ports'][index]
 
     def collect_auth_files(self):
         files = {}

--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -82,7 +82,7 @@ class Plugin(dork_compose.plugin.Plugin):
                             if external == '443':
                                 service['environment']['VIRTUAL_PROTO'] = 'https'
                             service['environment']['VIRTUAL_PORT'] = int(internal)
-                service['ports'] = []
+                            service['ports'] = []
 
     def collect_auth_files(self):
         files = {}


### PR DESCRIPTION
Currently the proxy plugin removes every exposed port, regardless if they are proxied or not.
Sometimes, especially when working from a local machine, you may wan't to expose a spefic port though.
In my case I would like to export the postgres port, so that i can use pycharm to connect to the database directly instead of using a somehting like phppgadmin (haven't found a good image for that yet). 

This pull request fixes the issue, by removing only the ports the where exposed to the proxy.
