### PR TITLE
Add ability to remove authentication from the proxy

### DIFF
--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -132,8 +132,6 @@ class Plugin(dork_compose.plugin.Plugin):
 
     def initializing(self, project, service_names=None):
         for service in project.get_services():
-            print service.name
-            print service.name not in self.auth['.no_auth']
             if self.auth_dir and 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment'] and service.name not in self.auth['.no_auth']:
                 lines = []
 

--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -132,13 +132,15 @@ class Plugin(dork_compose.plugin.Plugin):
 
     def initializing(self, project, service_names=None):
         for service in project.get_services():
-            if self.auth_dir and 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment']:
+            print service.name
+            print service.name not in self.auth['.no_auth']
+            if self.auth_dir and 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment'] and service.name not in self.auth['.no_auth']:
                 lines = []
 
                 if '.auth' in self.auth:
                     lines.extend(self.auth['.auth'])
 
-                if '.auth.%s' % service.name in self.auth and service.name not in self.auth['.no_auth']:
+                if '.auth.%s' % service.name in self.auth:
                     lines.extend(self.auth['.auth.%s' % service.name])
 
                 authfile = '%s/%s' % (self.auth_dir, service.options['environment']['VIRTUAL_HOST'])

--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -39,7 +39,7 @@ class Plugin(dork_compose.plugin.Plugin):
             if 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment']:
                 key = '"%s" url' % service.name
                 info[key] = service.options['environment'].get('VIRTUAL_PROTO', 'http') + '://' + service.options['environment']['VIRTUAL_HOST']
-                if '.auth' in auth or '.auth.%s' % service.name in auth:
+                if ('.auth' in auth or '.auth.%s' % service.name in auth) and service.name not in auth['.no_auth']:
                     info[key] += ' (password protected)'
         return info
 
@@ -91,7 +91,10 @@ class Plugin(dork_compose.plugin.Plugin):
                             del service['ports'][index]
 
     def collect_auth_files(self):
-        files = {}
+        files = {
+            '.no_auth': []
+        }
+
         path = filter(len, self.basedir.split('/'))
         current = ''
         while len(path):
@@ -109,17 +112,37 @@ class Plugin(dork_compose.plugin.Plugin):
                 with open(file) as f:
                     files[filename].append(f.read())
 
+            for file in glob.glob('%s/.no_auth*' % current):
+                filename = os.path.basename(file)
+                no_auth = filename.split('.no_auth.')
+                if len(no_auth) > 1:
+                    service = no_auth[1]
+
+                    auth_service = '.auth.%s' % service
+                    if auth_service in files:
+                       del files[auth_service]
+
+                    if '.no_auth' not in files:
+                        files['.no_auth'] = []
+                    files['.no_auth'].append(service)
+                else:
+                    del files['.auth']
+
         return files
 
     def initializing(self, project, service_names=None):
         for service in project.get_services():
             if self.auth_dir and 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment']:
                 lines = []
+
                 if '.auth' in self.auth:
                     lines.extend(self.auth['.auth'])
-                if '.auth.%s' % service.name in self.auth:
+
+                if '.auth.%s' % service.name in self.auth and service.name not in self.auth['.no_auth']:
                     lines.extend(self.auth['.auth.%s' % service.name])
+
                 authfile = '%s/%s' % (self.auth_dir, service.options['environment']['VIRTUAL_HOST'])
+
                 if lines:
                     with open(authfile, mode='w+') as f:
                         f.writelines(lines)

--- a/tests/lib/multiple/docker-compose.yml
+++ b/tests/lib/multiple/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  http:
+    image: nginx
+    ports:
+    - 80:80
+    volumes:
+    - ${DORK_SOURCE}:/usr/share/nginx/html
+
+  web:
+    image: nginx
+    ports:
+    - 5000:80
+    volumes:
+    - ${DORK_SOURCE}:/usr/share/nginx/html

--- a/tests/sources/auth/.auth
+++ b/tests/sources/auth/.auth
@@ -1,0 +1,1 @@
+dork:$apr1$GTPsRuxl$C6sW.SyKGAf1/cJ.DQ8fq0

--- a/tests/sources/auth/index.html
+++ b/tests/sources/auth/index.html
@@ -1,0 +1,1 @@
+<h1>Testpage.</h1>

--- a/tests/sources/auth/noauth/index.html
+++ b/tests/sources/auth/noauth/index.html
@@ -1,0 +1,1 @@
+<h1>Testpage.</h1>

--- a/tests/tests/auth.bats
+++ b/tests/tests/auth.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load common
+
+@test "Test authorization info" {
+  cd sources/auth
+
+  dork-compose info | grep 'password protected'
+}
+
+
+@test "Test authorization login" {
+  cd sources/auth
+
+  dork-compose up -d
+
+  # Test if the container started
+  docker ps | grep 'auth_http_1'
+
+  # Sleep to wait for the container to boot.
+  sleep 1
+
+  # Test if the container is accessible using no login.
+  curl -I --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '401 Unauthorized'
+
+  # Test if the container is accessible using no login.
+  curl -u dork:dork --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '<h1>Testpage.</h1>'
+
+  dork-compose down
+
+  # Test if the http service has been removed.
+  ! docker ps -a | grep 'simple_http_1'
+
+}

--- a/tests/tests/auth.bats
+++ b/tests/tests/auth.bats
@@ -25,13 +25,38 @@ load common
   curl -I --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '401 Unauthorized'
   curl -I --resolve web--auth.dork:80:127.0.0.1 http://web--auth.dork | grep '401 Unauthorized'
 
-  # Test if the container is accessible using no login.
+  # Test if the container is accessible using a login.
   curl -u dork:dork --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '<h1>Testpage.</h1>'
   curl -u dork:dork --resolve web--auth.dork:80:127.0.0.1 http://web--auth.dork | grep '<h1>Testpage.</h1>'
 
   dork-compose down
 
-  # Test if the http service has been removed.
-  ! docker ps -a | grep 'simple_http_1'
+  # Test if the services has been removed.
+  ! docker ps -a | grep 'auth_http_1'
+  ! docker ps -a | grep 'auth_web_1'
+}
 
+@test "Test authorization override for a service" {
+  cd sources/auth/noauth
+
+  dork-compose up -d
+
+  # Test if the containers started
+  docker ps | grep 'noauth_http_1'
+  docker ps | grep 'noauth_web_1'
+
+  # Sleep to wait for the container to boot.
+  sleep 1
+
+  # The main http container should be accessible using the login
+  curl -u dork:dork --resolve noauth.dork:80:127.0.0.1 http://noauth.dork | grep '<h1>Testpage.</h1>'
+
+  # The web container should be accessible with a login.
+  curl -u dork:dork --resolve web--noauth.dork:80:127.0.0.1 http://web--noauth.dork | grep '<h1>Testpage.</h1>'
+
+  dork-compose down
+
+  # Test if the services has been removed.
+  ! docker ps -a | grep 'noauth_http_1'
+  ! docker ps -a | grep 'noauth_web_1'
 }

--- a/tests/tests/auth.bats
+++ b/tests/tests/auth.bats
@@ -14,17 +14,20 @@ load common
 
   dork-compose up -d
 
-  # Test if the container started
+  # Test if the containers started
   docker ps | grep 'auth_http_1'
+  docker ps | grep 'auth_web_1'
 
   # Sleep to wait for the container to boot.
   sleep 1
 
-  # Test if the container is accessible using no login.
+  # Test if the containers are accessible using no login.
   curl -I --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '401 Unauthorized'
+  curl -I --resolve web--auth.dork:80:127.0.0.1 http://web--auth.dork | grep '401 Unauthorized'
 
   # Test if the container is accessible using no login.
   curl -u dork:dork --resolve auth.dork:80:127.0.0.1 http://auth.dork | grep '<h1>Testpage.</h1>'
+  curl -u dork:dork --resolve web--auth.dork:80:127.0.0.1 http://web--auth.dork | grep '<h1>Testpage.</h1>'
 
   dork-compose down
 


### PR DESCRIPTION
This pull requests allows you to remove access for a site or a certain service.

It works similar to the .auth files: Place a .no_auth file into a dir and the authentication for all services will be removed. If create a .no_auth.[service] only the authentication for the [service] will be removed.

The .no_auth files respect the folder hirachy, which means an .auth will override the .no_auth of a parent dir, the .no_auth.[service] currently doesn't. It will remove the authentication for all sub directories. 
