### PR TITLE
Changed client_max_body_size to 0 in proxy.

### DIFF
--- a/dork_compose/auxiliary/proxy/nginx/nginx.conf
+++ b/dork_compose/auxiliary/proxy/nginx/nginx.conf
@@ -27,6 +27,8 @@ http {
 
     #gzip  on;
 
+    client_max_body_size 0;
+
     server_names_hash_bucket_size 128;
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
This PR should sets the [client_max_body_size](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) to 0, so that doesn't check the client size.