### PR TITLE
Directory relationship check should actually check directories

### DIFF
--- a/dork_compose/helpers.py
+++ b/dork_compose/helpers.py
@@ -1,6 +1,13 @@
+import os;
+
 def tru(val):
     return val
 
-
 def notdefault(val):
     return val if val != 'default' else None
+
+def is_subdir(path, directory):
+    path = os.path.realpath(path)
+    directory = os.path.realpath(directory)
+    relative = os.path.relpath(path, directory)
+    return not (relative == os.pardir or relative.startswith(os.pardir + os.sep))

--- a/dork_compose/plugins/autobuild.py
+++ b/dork_compose/plugins/autobuild.py
@@ -1,6 +1,7 @@
 import dork_compose.plugin
 import os
 import shutil
+from dork_compose.helpers import is_subdir
 
 import six
 import sys
@@ -29,11 +30,13 @@ class Plugin(dork_compose.plugin.Plugin):
         }
 
     def building(self, service, no_cache, pull, force_rm):
+        
+
         context = service.options.get('build', {}).get('context', None)
         source = service.options.get('build', {}).get('source', '.')
         onbuild = service.options.get('build', {}).get('onbuild', None)
 
-        if not onbuild and context and not context.startswith(self.env['DORK_SOURCE']):
+        if not onbuild and context and not is_subdir(context, self.env['DORK_SOURCE']):
             dockerfile = service.options.get('build', {}).get('dockerfile', None)
 
             onbuild = "%s/%s:autobuild" % (


### PR DESCRIPTION
If your primary directory and the context directory are similar, dork can get confused in autobuild. My repo root is ~/Sites/mysite , and the dork-compose directory is ~/Sites/mysite-dork . 

Added a helper function for is_subdir, which uses os to make sure directory a is an actual subdirectory of directory b.