### PR TITLE
Fix auth bug, where htaccess only set for one service

### DIFF
--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -126,8 +126,9 @@ class Plugin(dork_compose.plugin.Plugin):
             auth = '%s/.auth' % current
             if os.path.isfile(auth):
                 with open(auth) as f:
+                    auth_data = f.read()
                     for service in services:
-                        files[service].append(f.read())
+                        files[service].append(auth_data)
 
             no_auth = '%s/.no_auth' % current
             if os.path.isfile(no_auth):


### PR DESCRIPTION
In this [commit](fa9647b91a9d33bf88393f8a07a5c54079aa56ab) a bug was introduced, where only for the first service of services list the authentication is set. The problem is, that you set the content by reading from the file pointer directly, which of course only works once 😄 .

Since this basically breaks our dev server it would be nice if you @pmelab could also create a new release, after merging this PR. I've patched the module directly on the dev2, which is not nice 😛 .
