### PR TITLE
Improve sync ignore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq bats
 - ./travis/clear-ports.sh
+- sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" > /etc/apt/sources.list.d/docker.list'
+- sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+- sudo apt-get update
+- sudo apt-key update
+- sudo apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine
+- docker -v
 
 install:
 - pip install -e .


### PR DESCRIPTION
Currently the hotcode plugin has a fixed list of file not to sync, instead of respecting the docker & dork ignore files. This means that files might not be ignored that should be ignored(like node_modules) and there also files missing, that are dork specific, which the syncing should ignore.

This PR fixes the issue by expanding the list and adding a routine which tries to read all dork & docker ignore files. 

I think we should also kick the .git out of this fixed list. If someone doesn't wants to not sync it, then it should be in a dockerignore file. The fixed list should only contain dork specific file patterns, which users might not know about.