### PR TITLE
Seperate network label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq bats
 - ./travis/clear-ports.sh
+- sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" > /etc/apt/sources.list.d/docker.list'
+- sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+- sudo apt-get update
+- sudo apt-key update
+- sudo apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine
+- docker -v
 
 install:
 - pip install -e .

--- a/dork_compose/auxiliary/dns/docker-compose.yml
+++ b/dork_compose/auxiliary/dns/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: andyshinn/dnsmasq:2.75
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     cap_add:
     - NET_ADMIN
     ports:

--- a/dork_compose/auxiliary/proxy/letsencrypt/docker-compose.yml
+++ b/dork_compose/auxiliary/proxy/letsencrypt/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: ../nginx
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     ports:
     - "80:80"
     - "443:443"
@@ -23,6 +24,7 @@ services:
     privileged: true
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     volumes_from:
     - nginx
     volumes:

--- a/dork_compose/auxiliary/proxy/none/docker-compose.yml
+++ b/dork_compose/auxiliary/proxy/none/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: ../nginx
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     ports:
     - "80:80"
     - "443:443"

--- a/dork_compose/auxiliary/proxy/selfsigned/docker-compose.yml
+++ b/dork_compose/auxiliary/proxy/selfsigned/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: ../nginx
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     ports:
     - "80:80"
     - "443:443"

--- a/dork_compose/auxiliary/vault/docker-compose.yml
+++ b/dork_compose/auxiliary/vault/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: vault:0.6.2
     labels:
     - org.iamdork.auxiliary
+    - org.iamdork.auxiliary.network
     privileged: true
     userns_mode: host
     cap_add:

--- a/dork_compose/plugin.py
+++ b/dork_compose/plugin.py
@@ -237,7 +237,7 @@ class Plugin(object):
 
             containers = client.containers(filters={
                 'label': [
-                    'org.iamdork.auxiliary',
+                    'org.iamdork.auxiliary.network',
                     'com.docker.compose.project=%s' % self.auxiliary_project_name
                 ],
             })


### PR DESCRIPTION
This PR introduces a seperate `org.iamdork.auxiliary.network` to attach auxiliary contains to others contairs network. Previosly this was done using the generic `org.iamdork.auxiliary`, but this caused a problem when dork-compose tries to attach the letsencrypt container to a network.