### PR TITLE
Add ability override the domain

### DIFF
--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -35,12 +35,22 @@ class Plugin(dork_compose.plugin.Plugin):
     def auxiliary_project(self):
         return pkg_resources.resource_filename('dork_compose', 'auxiliary/proxy/%s' % self.https_signing)
 
+    @property
+    def virtual_host(self):
+        return self.env.get('DORK_PROXY_VIRTUAL_HOST', '')
+
     def service_domain(self, service=None):
-        return '--'.join(filter(tru, [
-            service,
-            notdefault(self.project),
-            notdefault(self.instance)
-        ])) + '.' + self.proxy_domain
+        if self.virtual_host == '':
+            return '--'.join(filter(tru, [
+                service,
+                notdefault(self.project),
+                notdefault(self.instance)
+            ])) + '.' + self.proxy_domain
+        else:
+            return '--'.join(filter(tru, [
+                service,
+                self.virtual_host
+            ]))
 
     def info(self, project):
         info = {}


### PR DESCRIPTION
This PR adds a new variable `DORK_PROXY_VIRTUAL_HOST`, which allows you override the domain for a site. 
The new variable is needed, because only checking for the `VIRTUAL_HOST` in the `proxy.preprocess_config` function would only allow you to set the domain per docker-compose config, but in our case we want to set it per site we up in an .env file. It is also probably cleaner if all the associated services (like a phpmyadmin container) run under the same domain.
Currently the domains of subservices  are also splitted by two dashes, I'm not sure if we should actually split by a dot, so that they run a sub domain (i.e. phpmyadmin.example.dork). 