### PR TITLE
Fix auth files not concatenated correctly.

### DIFF
--- a/dork_compose/plugins/proxy.py
+++ b/dork_compose/plugins/proxy.py
@@ -184,7 +184,7 @@ class Plugin(dork_compose.plugin.Plugin):
 
         for service in project.get_services():
             if self.auth_dir and 'environment' in service.options and 'VIRTUAL_HOST' in service.options['environment']:
-                lines = auth[service.name]
+                lines = '\n'.join(auth[service.name])
                 authfile = '%s/%s' % (self.auth_dir, service.options['environment']['VIRTUAL_HOST'])
                 if lines:
                     if not os.path.isdir(self.auth_dir):


### PR DESCRIPTION
Currently there is a bug when collecting several .auth files and writing them to the specific password file. `proxy.collect_auth_files()` returns a list per service containing the content of the .auth and .auth.service files and later writes that list in the `initializing()` function directly to the password files. 
Python simply concatenates the list to a single string without any characters, but it should actually concatenated with a line break.