### PR TITLE
Subnet plugin

### DIFF
--- a/dork_compose/plugins/subnet.py
+++ b/dork_compose/plugins/subnet.py
@@ -121,14 +121,14 @@ class Subnet:
 
         to_add = [0] * part
         to_add.append(1)
-        to_add = to_add + [0] * (4-len(to_add))
+        to_add = to_add + [0] * (4 - len(to_add))
 
         tmp = Subnet.__add_ips(self.last, to_add)
 
         ip = []
         carry = 0
         for x in reversed(tmp):
-            if carry>0:
+            if carry > 0:
                 sum = x + carry
                 if sum > 255:
                     ip.insert(0, 0)
@@ -170,17 +170,20 @@ class Plugin(dork_compose.plugin.Plugin):
     """
     default_subnet = Subnet("172.20.0.0/24")
 
-    def preprocess_config(self, config):
+    def initializing(self, project, service_names=None):
         subnet = self.__get_free_subnet()
-
-        # todo: add new network section to config and services
+        project.networks.networks['default'].ipam = {
+            'Driver': 'default',
+            'Config': [
+                {'Subnet': str(subnet)},
+            ]
+        }
 
     def __get_free_subnet(self):
         client = docker_client(self.env)
         subnets = []
         for network in client.networks():
             for config in network['IPAM']['Config']:
-                print(config['Subnet'])
                 subnets.append(Subnet(config['Subnet']))
 
         res = self.default_subnet
@@ -195,5 +198,3 @@ class Plugin(dork_compose.plugin.Plugin):
                     overlaps = False
 
         return res
-
-

--- a/dork_compose/plugins/subnet.py
+++ b/dork_compose/plugins/subnet.py
@@ -1,0 +1,199 @@
+import dork_compose.plugin
+from compose.cli.docker_client import docker_client
+
+
+class Subnet:
+    """
+    Represents one subnet and provides useful calculation methods.
+    """
+
+    def __init__(self, subnet="", ip=[], cidr=None):
+        """
+        Create a new subnet either by parsing the ip/cidr notation or setting
+        an ip and the cidr.
+
+        :param subnet: A string with ip/cidr to create a new subnet
+        :param ip: A ip to create a new subnet, cidr is required as well.
+        :param cidr: A cidr to create a new subnet, the ip is required as well.
+        """
+        if subnet != "":
+            tmp = subnet.split('/')
+            self.__cidr = int(tmp[1])
+
+            ip = [int(x) for x in tmp[0].split('.')]
+        elif len(ip) == 4 and cidr != None:
+            self.__cidr = cidr
+
+        self.__net = Subnet.__ip_and(ip, self.net_mask)
+
+    def overlaps(self, subnet):
+        """
+        Checks if the given subnet intersects with this subnet.
+        :param subnet: A Subnet object.
+        :return: True if they overlap, False if not.
+        """
+        if subnet.cidr < self.cidr:
+            cidr = subnet.cidr
+        else:
+            cidr = self.cidr
+
+        if cidr <= 8:
+            to_check = 0
+        elif 8 < cidr <= 16:
+            to_check = 1
+        elif 16 < cidr <= 24:
+            to_check = 2
+        else:
+            to_check = 3
+
+        for x, y in zip(subnet.net, self.net)[0:to_check]:
+            if x != y:
+                return False
+
+        if (self.last[to_check] < subnet.first[to_check]) or \
+                (self.first[to_check] > subnet.last[to_check]):
+            return False
+        else:
+            return True
+
+    @property
+    def cidr(self):
+        """
+        Returns the CIDR
+        """
+        return self.__cidr
+
+    @property
+    def net(self):
+        """
+        Returns the net
+        """
+        return self.__net
+
+    @property
+    def net_mask(self):
+        """
+        Calculates & returns the net mask out of the CIDR.
+        https://stackoverflow.com/a/43904598/4265508
+        """
+        mask = (0xffffffff >> (32 - self.cidr)) << (32 - self.cidr)
+
+        return Subnet.__create_mask(mask)
+
+    @property
+    def wild_card(self):
+        """
+        Calculates & returns the wild card mask out of the CIDR.
+        """
+        mask = ~((0xffffffff >> (32 - self.cidr))
+                 << (32 - self.cidr)) & 0xffffffff
+
+        return Subnet.__create_mask(mask)
+
+    @property
+    def first(self):
+        """
+        Returns the first ip of this subnet.
+        """
+        return self.__net
+
+    @property
+    def last(self):
+        """
+        Returns the last ip of this subnet
+        """
+        return Subnet.__add_ips(self.net, self.wild_card)
+
+    @property
+    def next_net(self):
+        """
+        Returns the next available subnet with the same subnet mask.
+        :return: A subnet object
+        """
+        if self.cidr <= 8:
+            part = 0
+        elif 8 < self.cidr <= 16:
+            part = 1
+        elif 16 < self.cidr <= 24:
+            part = 2
+        else:
+            part = 3
+
+        to_add = [0] * part
+        to_add.append(1)
+        to_add = to_add + [0] * (4-len(to_add))
+
+        tmp = Subnet.__add_ips(self.last, to_add)
+
+        ip = []
+        carry = 0
+        for x in reversed(tmp):
+            if carry>0:
+                sum = x + carry
+                if sum > 255:
+                    ip.insert(0, 0)
+                else:
+                    ip.insert(0, sum)
+                    carry = 0
+            else:
+                if x > 255:
+                    ip.insert(0, 0)
+                    carry = 1
+                else:
+                    ip.insert(0, x)
+
+        return Subnet(ip=ip, cidr=self.cidr)
+
+    def __str__(self):
+        net = ".".join(str(x) for x in self.net)
+        return "%s/%i" % (net, self.cidr)
+
+    @staticmethod
+    def __ip_and(ip1, ip2):
+        return [x & y for x, y, in zip(ip1, ip2)]
+
+    @staticmethod
+    def __add_ips(ip1, ip2):
+        return [x + y for x, y in zip(ip1, ip2)]
+
+    @staticmethod
+    def __create_mask(mask):
+        return [(0xff000000 & mask) >> 24,
+                (0x00ff0000 & mask) >> 16,
+                (0x0000ff00 & mask) >> 8,
+                (0x000000ff & mask)]
+
+
+class Plugin(dork_compose.plugin.Plugin):
+    """
+    This plugin allows to inject a subnet
+    """
+    default_subnet = Subnet("172.20.0.0/24")
+
+    def preprocess_config(self, config):
+        subnet = self.__get_free_subnet()
+
+        # todo: add new network section to config and services
+
+    def __get_free_subnet(self):
+        client = docker_client(self.env)
+        subnets = []
+        for network in client.networks():
+            for config in network['IPAM']['Config']:
+                print(config['Subnet'])
+                subnets.append(Subnet(config['Subnet']))
+
+        res = self.default_subnet
+        overlaps = True
+        while overlaps:
+            for subnet in subnets:
+                if subnet.overlaps(res):
+                    overlaps = True
+                    res = res.next_net
+                    break
+                else:
+                    overlaps = False
+
+        return res
+
+

--- a/tests/tests/subnet.bats
+++ b/tests/tests/subnet.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+load common
+
+get_subnet() {
+  echo $(docker network inspect "$1" \
+    | python -c 'import json,sys;obj=json.load(sys.stdin);print obj[0]["IPAM"]["Config"][0]["Subnet"];')
+}
+
+
+@test "Test setting a certain subnet" {
+  export DORK_PLUGINS="env:multi:lib:proxy:dns:subnet"
+  export DORK_SUBNET_DEFAULT="10.0.0.0/24"
+  cd $SOURCES/simple
+
+  dork-compose up -d
+
+  network=$(get_subnet "simple_default")
+
+  # This is the first network which was created, therefore the network should
+  # match the default subnet.
+  [ "$network" == "$DORK_SUBNET_DEFAULT" ]
+
+  dork-compose down -v --rmi local
+
+}
+
+@test "Test creating several projects with a managed subnet" {
+  export DORK_PLUGINS="env:multi:lib:proxy:dns:subnet"
+  export DORK_SUBNET_DEFAULT="192.168.1.0/28"
+  cd $SOURCES/multi/one && dork-compose up -d
+  cd $SOURCES/multi/two && dork-compose up -d
+  cd $SOURCES/multi/three && dork-compose up -d
+
+  # Check if the first network is correct.
+  network1=$(get_subnet "one_default")
+  [ "$network1" == "192.168.1.0/28" ]
+
+  # Check if the second network is correct.
+  network2=$(get_subnet "two_default")
+  [ "$network2" == "192.168.1.16/28" ]
+
+  # Check if the third network is correct.
+  network3=$(get_subnet "three_default")
+  [ "$network3" == "192.168.1.32/28" ]
+
+  cd $SOURCES/multi/one && dork-compose down -v --rmi local
+  cd $SOURCES/multi/two && dork-compose down -v --rmi local
+  cd $SOURCES/multi/three && dork-compose down -v --rmi local
+}
+
+@test "Test creating a project with managed subnet besides existing project" {
+  # Up a project without the subnet plugin
+  export DORK_PLUGINS="env:multi:lib:proxy:dns"
+  cd $SOURCES/multi/one && dork-compose up -d
+
+  # Up a project with the subnet plugin.
+  export DORK_PLUGINS="env:multi:lib:proxy:dns:subnet"
+  export DORK_SUBNET_DEFAULT="10.0.0.0/24"
+  cd $SOURCES/multi/two && dork-compose up -d
+
+  # Check if the first network is correct.
+  network=$(get_subnet "two_default")
+  [ "$network" == "$DORK_SUBNET_DEFAULT" ]
+
+  cd $SOURCES/multi/one && dork-compose down -v --rmi local
+  cd $SOURCES/multi/two && dork-compose down -v --rmi local
+}


### PR DESCRIPTION
Currently docker manages networks by itself, if no subnet is passed when creating networks. The default subnets are `172.[17-31].0.0/16` and `192.168.[0-240].0/20`, which means the amounts of subnets and therefore applications you can up on single node is limited to about 32. This is a very small number, especially on dev servers, where multiple people work on a lot of different sites and also for our demo server.
There are efforts to allow to define a default pool of networks for the docker daemon, see moby/moby#29376, but due to incompatibilities with the overlay network used for swarm, it seems unlikely that this feature will be implemented soon. 
This PR therefore tries to implement a plugin, which will allow to set a default network pool and inject the subnet config into the services.